### PR TITLE
fix: Remove an unnecessary line from basic javascript challenge

### DIFF
--- a/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
+++ b/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
@@ -2212,7 +2212,7 @@
       "id": "56533eb9ac21ba0edf2244bb",
       "title": "Word Blanks",
       "description": [
-        "We will now use our knowledge of strings to build a \"<a href='https://en.wikipedia.org/wiki/Mad_Libs' target='_blank'>Mad Libs</a>\" style word game we're calling \"Word Blanks\". You will create an (optionally humorous) \"Fill in the Blanks\" style sentence. Here's an example of an incomplete sentence.",
+        "We will now use our knowledge of strings to build a \"<a href='https://en.wikipedia.org/wiki/Mad_Libs' target='_blank'>Mad Libs</a>\" style word game we're calling \"Word Blanks\". You will create an (optionally humorous) \"Fill in the Blanks\" style sentence.",
         "In a \"Mad Libs\" game, you are provided sentences with some missing words, like nouns, verbs, adjectives and adverbs. You then fill in the missing pieces with words of your choice in a way that the completed sentence makes sense.",
         "Consider this sentence - \"It was really <strong>____</strong>, and we <strong>____</strong> ourselves <strong>____</strong>\". This sentence has three missing pieces- an adjective, a verb and an adverb, and we can add words of our choice to complete it. We can then assign the completed sentence to a variable as follows:",
         "<blockquote>var sentence = \"It was really\" + \"hot\" + \", and we\" + \"laughed\" + \"ourselves\" + \"silly.\";</blockquote>",


### PR DESCRIPTION
This PR fixes [#17580](https://github.com/freeCodeCamp/freeCodeCamp/issues/17580).

The line `Here's an example of an incomplete sentence.` was unnecessary and was only causing confusion. As discussed in the issue page, I felt that removing the line doesn't make the challenge any less clear but does indeed shortens the length of the challenge text.

If you feel that adding the example was better idea then I will add the example. Please take a look. Thanks.