### PR TITLE
fix(challenges): Applied Accessibility - Improve Accessibility of Audio Content with the audio Element

### DIFF
--- a/challenges/01-responsive-web-design/applied-accessibility.json
+++ b/challenges/01-responsive-web-design/applied-accessibility.json
@@ -521,7 +521,7 @@
           "text":
             "Make sure your <code>audio</code> element has a closing tag.",
           "testString":
-            "assert(code.match(/<\\/audio>/g) && code.match(/<audio controls>/g) && code.match(/<\\/audio>/g).length === code.match(/<audio controls>/g).length, 'Make sure your <code>audio</code> element has a closing tag.');"
+            "assert(code.match(/<\\/audio>/g).length === 1 && code.match(/<audio.*>[\\s\\S]*<\\/audio>/g), 'Make sure your <code>audio</code> element has a closing tag.');"
         },
         {
           "text":


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `dev` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

BREAKING CHANGE:
none

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17729
Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17723
Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17623
Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17577
Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17477

#### Description
<!-- Describe your changes in detail -->
The assertion for a closing audio tag has 3 conditions that linked by `&&` operators. Two of them always return false, therefore fail the test.
```
// Returns true if the input has a closing tag
code.match(/<\\/audio>/g) 

// Doesn't match anything and returns null
// because the challenge seed
// has an 'id' between 'audio' and 'controls'
code.match(/<audio controls>/g)

// Same as above
code.match(/<\\/audio>/g).length === code.match(/<audio controls>/g).length
```
I think the second and third condition are not necessary because we have another test case that checks if we have exactly one opening tag.

My proposal fix is to check if there is also one closing tag && the closing tag goes after the opening one.