### PR TITLE
fix(challenges): update RegEx for testcase in es6 challenge

### DIFF
--- a/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -1341,12 +1341,12 @@
         {
           "text": "<code>foo</code> is exported.",
           "testString":
-            "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+foo\\s+=+\\s\"bar\"/g), '<code>foo</code> is exported.');"
+            "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+foo\\s*=\\s*\"bar\"/g), '<code>foo</code> is exported.');"
         },
         {
           "text": "<code>bar</code> is exported.",
           "testString":
-            "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+bar\\s+=+\\s\"foo\"/g), '<code>bar</code> is exported.');"
+            "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+bar\\s*=\\s*\"foo\"/g), '<code>bar</code> is exported.');"
         }
       ],
       "releasedOn": "Feb 17, 2017",
@@ -1360,7 +1360,7 @@
           "contents": [
             "\"use strict\";",
             "const foo = \"bar\";",
-            "const bar= \"foo\";"
+            "const bar = \"foo\";"
           ],
           "head": ["window.exports = function(){};"],
           "tail": []


### PR DESCRIPTION
#### Description
I have updated the RegEx for the test cases of [this challenge](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/es6/use-export-to-reuse-a-code-block). This is related to the [#17771](https://github.com/freeCodeCamp/freeCodeCamp/issues/17771).

This new RegEx makes `space` optional after and before `=` which was the reason for the test failure in [#17771](https://github.com/freeCodeCamp/freeCodeCamp/issues/17771). It also takes care of any number of `space` characters after and before the `=`. 

```js
export const foo="bar"
export const foo = "bar"
export const foo            =          "bar"
```

Above all three cases will pass the test now as they are valid js code.

Please take a look.

#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes [#17771](https://github.com/freeCodeCamp/freeCodeCamp/issues/17771)
