### PR TITLE
fix(challenges): fix regex in applied visual design challenge

### DIFF
--- a/challenges/01-responsive-web-design/applied-visual-design.json
+++ b/challenges/01-responsive-web-design/applied-visual-design.json
@@ -2307,7 +2307,7 @@
           "text":
             "Your <code>body</code> element should have a <code>background</code> property set to a <code>url()</code> with the given link.",
           "testString":
-            "assert(code.match(/background:\\s*?url\\((\"|')https:\\/\\/i\\.imgur\\.com\\/MJAkxbh\\.png(\"|')\\)/gi), 'Your <code>body</code> element should have a <code>background</code> property set to a <code>url()</code> with the given link.');"
+            "assert(code.match(/background:\\s*?url\\((\"|'|)https:\\/\\/i\\.imgur\\.com\\/MJAkxbh\\.png\\1\\)/gi), 'Your <code>body</code> element should have a <code>background</code> property set to a <code>url()</code> with the given link.');"
         }
       ],
       "solutions": [],

--- a/challenges/01-responsive-web-design/applied-visual-design.json
+++ b/challenges/01-responsive-web-design/applied-visual-design.json
@@ -2307,7 +2307,7 @@
           "text":
             "Your <code>body</code> element should have a <code>background</code> property set to a <code>url()</code> with the given link.",
           "testString":
-            "assert(code.match(/background:\\s*?url\\((\"|'|)https:\\/\\/i\\.imgur\\.com\\/MJAkxbh\\.png\\1\\)/gi), 'Your <code>body</code> element should have a <code>background</code> property set to a <code>url()</code> with the given link.');"
+            "assert(code.match(/background:\\s*?url\\(\\s*(\"|'|)https:\\/\\/i\\.imgur\\.com\\/MJAkxbh\\.png\\1\\s*\\)/gi), 'Your <code>body</code> element should have a <code>background</code> property set to a <code>url()</code> with the given link.');"
         }
       ],
       "solutions": [],


### PR DESCRIPTION
Updates the regex of the background image challenge to use numeric references that prevent the tests from accepting mismatched quotes. It also allows the user to enter the url without quotes as that is also valid css.

ISSUES CLOSED: #161
