### PR TITLE
fix(challenges): typo in javascript algorithms/debugging/2

### DIFF
--- a/challenges/02-javascript-algorithms-and-data-structures/debugging.json
+++ b/challenges/02-javascript-algorithms-and-data-structures/debugging.json
@@ -67,9 +67,9 @@
       "tests": [
         {
           "text":
-            "Use <code>console.log()</code> to print the <code>outputTwice</code> variable.  In your Browser Console this should print out the value of the variable two times.",
+            "Use <code>console.log()</code> to print the <code>outputTwo</code> variable.  In your Browser Console this should print out the value of the variable two times.",
           "testString":
-            "assert(code.match(/console\\.log\\(outputTwo\\)/g), 'Use <code>console.log()</code> to print the <code>outputTwice</code> variable.  In your Browser Console this should print out the value of the variable two times.');"
+            "assert(code.match(/console\\.log\\(outputTwo\\)/g), 'Use <code>console.log()</code> to print the <code>outputTwo</code> variable.  In your Browser Console this should print out the value of the variable two times.');"
         },
         {
           "text":


### PR DESCRIPTION
In the objectives, the user was asked to log the variable "outputTwice" whereas in the code editor,
no such variable existed. I changed the objectif so that  it states to change the variable
"outputTwo" which is the variable found in the content.

#### Description

As Stated above, the variable of the objectives in the challenge "Debugging: Understanding the Differences between the freeCodeCamp and Browser Console" are not the same as the ones in the code editor. I just changed the variable "outputTwice" in the objectives into "outputTwo"


#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes freeCodeCamp/freeCodeCamp#17914

