### PR TITLE
fix(challenges): fix third test for template literals

### DIFF
--- a/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -996,7 +996,7 @@
         "<blockquote>const person = {<br>&nbsp;&nbsp;name: \"Zodiac Hasbro\",<br>&nbsp;&nbsp;age: 56<br>};<br><br>// Template literal with multi-line and string interpolation<br>const greeting = `Hello, my name is ${person.name}!<br>I am ${person.age} years old.`;<br><br>console.log(greeting); // prints<br>// Hello, my name is Zodiac Hasbro!<br>// I am 56 years old.<br></blockquote>",
         "A lot of things happened there.",
         "Firstly, the example uses backticks (<code>`</code>), not quotes (<code>'</code> or <code>\"</code>), to wrap the string.",
-        "Secondly, notice that the string is multi-line, both in the code and the output. This saves inserting \n within strings.",
+        "Secondly, notice that the string is multi-line, both in the code and the output. This saves inserting <code>\n</code> within strings.",
         "The <code>${variable}</code> syntax used above is a placeholder. Basically, you won't have to use concatenation with the <code>+</code> operator anymore. To add variables to strings, you just drop the variable in a template string and wrap it with <code>${</code> and <code>}</code>. Similarly, you can include other expressions in your string literal, for example <code>${a + b}</code>.",
         "This new way of creating strings gives you more flexibility to create robust strings.",
         "<hr>",
@@ -1017,7 +1017,7 @@
         {
           "text": "Template strings were used",
           "testString":
-            "getUserInput => assert(getUserInput('index').match(/`<li \\s*class\\s*=\\s*(\"\\s*text-warning\\s*\"|'\\s*text-warning\\s*')\\s*>\\s*\\$\\s*\\{(\\s*\\w+\\s*|\\s*\\w+\\s*\\[\\s*[\\w]+\\s*\\]\\s*)\\}\\s*<\\s*\\/li\\s*>`/g), 'Template strings were used');"
+            "getUserInput => assert(getUserInput('index').match(/`.*`/g), 'Template strings were used');"
         }
       ],
       "releasedOn": "Feb 17, 2017",


### PR DESCRIPTION
#### Description
replaced the overly long and complex regex which tests for use of template literals with a much
simpler one that has the same effect

also fixed `\n` not being displayed as it was not escaped or surrounded by code tags

ISSUES CLOSED: #135
<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #135 

