### PR TITLE
fix(challenges): add test to lookahead regex challenge

### DIFF
--- a/challenges/02-javascript-algorithms-and-data-structures/regular-expressions.json
+++ b/challenges/02-javascript-algorithms-and-data-structures/regular-expressions.json
@@ -1514,6 +1514,10 @@
           "testString": "assert(!pwRegex.test(\"airplanes\"), 'Your regex should not match <code>\"airplanes\"</code>');"
         },
         {
+          "text": "Your regex should not match <code>\"banan1\"</code>",
+          "testString": "assert(!pwRegex.test(\"banan1\"), 'Your regex should not match <code>\"banan1\"</code>');"
+        },
+        {
           "text": "Your regex should match <code>\"bana12\"</code>",
           "testString": "assert(pwRegex.test(\"bana12\"), 'Your regex should match <code>\"bana12\"</code>');"
         },
@@ -1530,7 +1534,7 @@
           "testString": "assert(!pwRegex.test(\"1234\"), 'Your regex should not match <code>\"1234\"</code>');"
         }
       ],
-      "solutions": [],
+      "solutions": ["var pwRegex = /(?=\\w{5})(?=\\D*\\d{2})/;"],
       "hints": [],
       "releasedOn": "Feb 17, 2017",
       "challengeType": 1,


### PR DESCRIPTION
There was no test to make sure inputs with only one digit would fail. I added the test and then added a solution as well.

ISSUES CLOSED: #209
