### PR TITLE
fix:Minor grammar mistake in CSS Grid:  #17990 Typo fixed

### DIFF
--- a/challenges/01-responsive-web-design/css-grid.json
+++ b/challenges/01-responsive-web-design/css-grid.json
@@ -1170,7 +1170,7 @@
       "id": "5a94fe5469fb03452672e461",
       "title": "Create Flexible Layouts Using auto-fill",
       "description": [
-        "The repeat function comes with a option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>.",
+        "The repeat function comes with an option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>.",
         "In the preview, <code>grid-template-columns</code> is set to",
         "<blockquote>repeat(auto-fill, minmax(60px, 1fr));</blockquote>",
         "When the container changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.",


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail below this line-->
Minor grammar mistake in CSS Grid: Create Flexible Layouts Using auto-fill
The first sentence says: "The repeat function comes with a option called auto-fill." The article "a" is incorrect. Should be "an option".

<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x ] Your pull request targets the `dev` branch.
- [x ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [ ] All new and existing tests pass the command `npm test`.
- [ ] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x ] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x ] Tested changes locally.
- [x ] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #17990

