### PR TITLE
docs(contributing): add info on conventional commit messages

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -275,9 +275,11 @@ $ git add path/to/filename.ext
 
 You can also run `git add .` to add all unstaged files. Take care, though, because you can accidentally add files you don't want added. Review your `git status` first.
 
-### Commit Your Changes 
+### Commit Your Changes
 
-We have a [tool](https://commitizen.github.io/cz-cli/) that helps you make standard commit messages. Execute `npm run commit` and follow the steps.
+We have a [tool](https://commitizen.github.io/cz-cli/) that helps you make standard commit messages. Execute `npm run commit` and follow the steps. This will generate a conventional commit message.  
+
+**Note**: Your pull request will fail the Travis CI build if your commits do not have conventional messages. [Click here](https://conventionalcommits.org/#why-use-conventional-commits) to read more about conventional commit messages.
 
 If you want to add/remove changes to previous commit, [add the files](#making-your-changes), and use `git commit --amend` or `git commit --amend --no-edit` (to keep the same commit message).
 


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail below this line-->

Specifies that a pull request will fail the Travis CI build without conventional commit messages and
adds a link with more info about conventional commits.

<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [ ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #XXXXX

