### PR TITLE
Typo in Basic Data Structures: Combine Arrays with the Spread Operator #18003 FIX

### DIFF
--- a/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
+++ b/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
@@ -468,7 +468,7 @@
       "description": [
         "Another huge advantage of the <dfn>spread</dfn> operator, is the ability to combine arrays, or to insert all the elements of one array into another, at any index. With more traditional syntaxes, we can concatenate arrays, but this only allows us to combine arrays at the end of one, and at the start of another. Spread syntax makes the following operation extremely simple:",
         "<blockquote>let thisArray = ['sage', 'rosemary', 'parsley', 'thyme'];<br><br>let thatArray = ['basil', 'cilantro', ...thisArray, 'coriander'];<br>// thatArray now equals ['basil', 'cilantro', 'sage', 'rosemary', 'parsley', 'thyme', 'coriander']</blockquote>",
-        "Using spread syntax, we have just achieved an operation that would have been more more complex and more verbose had we used traditional methods.",
+        "Using spread syntax, we have just achieved an operation that would have been more complex and more verbose had we used traditional methods.",
         "<hr>",
         "We have defined a function <code>spreadOut</code> that returns the variable <code>sentence</code>, modify the function using the <dfn>spread</dfn> operator so that it returns the array <code>['learning', 'to', 'code', 'is', 'fun']</code>."
       ],


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail below this line-->
Fixing typo in algorithms and data structures lesson having to do with combining arrays with the spread operator. Deleted the multiple word 'more'.




<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [X] Your pull request targets the `dev` branch.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [X] All new and existing tests pass the command `npm test`.
- [X] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [X] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [X] Tested changes locally.
- [X] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/18003

