### PR TITLE
fix(challenges): fix flex direction row regex

### DIFF
--- a/challenges/01-responsive-web-design/css-flexbox.json
+++ b/challenges/01-responsive-web-design/css-flexbox.json
@@ -272,11 +272,11 @@
       "tests": [
         {
           "text": "The <code>header</code> should have a <code>flex-direction</code> property set to row.",
-          "testString": "assert(code.match(/header\\s*?{\\s*?.*?\\s*?.*?\\s*?flex-direction:\\s*?row;/g), 'The <code>header</code> should have a <code>flex-direction</code> property set to row.');"
+          "testString": "assert(code.match(/header\\s*?{[^}]*?flex-direction:\\s*?row;/g), 'The <code>header</code> should have a <code>flex-direction</code> property set to row.');"
         },
         {
           "text": "The <code>footer</code> should have a <code>flex-direction</code> property set to row.",
-          "testString": "assert(code.match(/footer\\s*?{\\s*?.*?\\s*?.*?\\s*?flex-direction:\\s*?row;/g), 'The <code>footer</code> should have a <code>flex-direction</code> property set to row.');"
+          "testString": "assert(code.match(/footer\\s*?{[^}]*?flex-direction:\\s*?row;/g), 'The <code>footer</code> should have a <code>flex-direction</code> property set to row.');"
         }
       ],
       "solutions": [


### PR DESCRIPTION
ISSUES CLOSED: #260

#### Description
<!-- Describe your changes in detail below this line-->
I improved regex for this challenge a little bit by ensuring the flex-direction declarations are in the right rules while also removing the line number restriction. 

I also thought about using jQuery in the tests, but that is not possible here because row is already the default value of `flex-direction`, so you could pass the challenge without doing anything.


<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #260

