### PR TITLE
fix(challenges): fix description in css variable fallback challenge

### DIFF
--- a/challenges/01-responsive-web-design/basic-css.json
+++ b/challenges/01-responsive-web-design/basic-css.json
@@ -5020,14 +5020,14 @@
       "id": "5a9d7286424fe3d0e10cad13",
       "title": "Attach a Fallback value to a CSS Variable",
       "description": [
-        "When using your variable as a CSS property value, you can attach a fallback value that your page will revert to if for some reason it can't get your variable to work.",
-        "It could be that someone is using an older browser that hasn't yet adopted CSS Variables, or perhaps their device doesn't support the value you gave the variable. Here's how you do it:",
+        "When using your variable as a CSS property value, you can attach a fallback value that your browser will revert to if the given variable is invalid.",
+        "<strong>Note:</strong> This fallback is not used to increase browser compatibilty, and it will not work on IE browsers. Rather, it is used so that the browser has a color to display if it cannot find your variable.",
+        "Here's how you do it:",
         "<blockquote>background: var(--penguin-skin, black);</blockquote>",
-        "This will set background to black if there is a problem with your variable.",
+        "This will set background to black if your variable wasn't set.",
         "Note that this can be useful for debugging.",
         "<hr>",
-        "Add a fallback value of <code>black</code> to the <code>background</code> property of <code>penguin-top</code> and <code>penguin-bottom</code> classes.",
-        "<strong>Note</strong>: The above style will be applied because of a typo in the CSS variable name."
+        "It looks there is a problem with the variables supplied to the <code>.penguin-top</code> and <code>.penguin-bottom</code> classes. Rather than fix the typo, add a fallback value of <code>black</code> to the <code>background</code> property of the <code>.penguin-top</code> and <code>.penguin-bottom</code> classes."
       ],
       "tests": [
         {


### PR DESCRIPTION


#### Description
<!-- Describe your changes in detail below this line-->
I fixed the description in this [challenge](https://learn.freecodecamp.org/responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable/) to point out that the variable fallback is not used to work with browsers that don't support variables.

I also updated the instruction to call out exactly what is going on rather than explaining it as a note at the bottom.



<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

PARTIALLY RESOLVES: freeCodeCamp/freeCodeCamp#17546

