### PR TITLE
fix(challenges): Fix typo in wrap-reverse description

### DIFF
--- a/challenges/01-responsive-web-design/css-flexbox.json
+++ b/challenges/01-responsive-web-design/css-flexbox.json
@@ -933,7 +933,7 @@
         "CSS flexbox has a feature to split a flex item into multiple rows (or columns). By default, a flex container will fit all flex items together. For example, a row will all be on one line.",
         "However, using the <code>flex-wrap</code> property, it tells CSS to wrap items. This means extra items move into a new row or column. The break point of where the wrapping happens depends on the size of the items and the size of the container.",
         "CSS also has options for the direction of the wrap:",
-        "<ul><li><code>nowrap</code>: this is the default setting, and does not wrap items.</li><li><code>wrap</code>: wraps items from left-to-right if they are in a row, or top-to-bottom if they are in a column.</li><li><code>wrap-reverse</code>: wraps items from bottom-to-top if they are in a row, or left-to-right if they are in a column.</li></ul>",
+        "<ul><li><code>nowrap</code>: this is the default setting, and does not wrap items.</li><li><code>wrap</code>: wraps items from left-to-right if they are in a row, or top-to-bottom if they are in a column.</li><li><code>wrap-reverse</code>: wraps items from bottom-to-top if they are in a row, or right-to-left if they are in a column.</li></ul>",
         "<hr>",
         "The current layout has too many boxes for one row. Add the CSS property <code>flex-wrap</code> to the <code>#box-container</code> element, and give it a value of wrap."
       ],


### PR DESCRIPTION
#### Description

Fix typo in wrap-reverse description. (see #287)

Change description of `wrap-reverse` from

- "wraps items from bottom-to-top if they are in a row, or **left-to-right** if they are in a column", to
- "wraps items from bottom-to-top if they are in a row, or **right-to-left** if they are in a column".

_Note: I haven't set up the entire testing environment for such a tiny typo, so the testing wasn't done locally._ 

<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
<!-- - [ ] All new and existing tests pass the command `npm test`.
- [ ] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits> -->
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

<!-- - [ ] Tested changes locally. -->
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #287 

