### PR TITLE
fix(challenges): adding code tags to description

### DIFF
--- a/challenges/06-information-security-and-quality-assurance/helmetjs.json
+++ b/challenges/06-information-security-and-quality-assurance/helmetjs.json
@@ -51,8 +51,8 @@
       "title": "Mitigate the Risk of Clickjacking with helmet.frameguard()",
       "description": [
         "As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-infosec/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-infosec/'>GitHub</a>.",
-        "Your page could be put in a &lt;frame&gt; or &lt;iframe&gt; without your consent. This can result in clickjacking attacks, among other things. Clickjacking is a technique of tricking a user into interacting with a page different from what the user thinks it is. This can be obtained executing your page in a malicious context, by mean of iframing. In that context a hacker can put a hidden layer over your page. Hidden buttons can be used to run bad scripts. This middleware sets the X-Frame-Options header. It restricts who can put your site in a frame. It has three modes: DENY, SAMEORIGIN, and ALLOW-FROM.",
-        "We don’t need our app to be framed. You should use helmet.frameguard() passing with the configuration object {action: 'deny'}."
+        "Your page could be put in a <code>&lt;frame&gt;</code> or <code>&lt;iframe&gt;</code> without your consent. This can result in clickjacking attacks, among other things. Clickjacking is a technique of tricking a user into interacting with a page different from what the user thinks it is. This can be obtained executing your page in a malicious context, by mean of iframing. In that context a hacker can put a hidden layer over your page. Hidden buttons can be used to run bad scripts. This middleware sets the X-Frame-Options header. It restricts who can put your site in a frame. It has three modes: DENY, SAMEORIGIN, and ALLOW-FROM.",
+        "We don’t need our app to be framed. You should use <code>helmet.frameguard()</code> passing with the configuration object <code>{action: 'deny'}</code>."
       ],
       "tests": [
         {


### PR DESCRIPTION
frames and other code in description were not surrounded by `<code>` tags and rendering poorly on
page.

ISSUES CLOSED: #17911-freecodecamp
https://github.com/freeCodeCamp/freeCodeCamp/issues/17911

#### Description
<!-- Describe your changes in detail below this line-->





<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #17911
https://github.com/freeCodeCamp/freeCodeCamp/issues/17911

