### PR TITLE
feat(scripts): add testing for React/Redux challenges

### DIFF
--- a/getChallenges.js
+++ b/getChallenges.js
@@ -60,9 +60,6 @@ module.exports = function getChallenges(challengesDir) {
         'MDNlinks',
         'null',
         'rawSolutions',
-        'react',
-        'reactRedux',
-        'redux',
         'type'
       ])
     );

--- a/schema/challengeSchema.js
+++ b/schema/challengeSchema.js
@@ -38,6 +38,9 @@ const schema = Joi.object().keys({
   isRequired: Joi.bool(),
   name: Joi.string(),
   order: Joi.number(),
+  react: Joi.bool(),
+  reactRedux: Joi.bool(),
+  redux: Joi.bool(),
   required: Joi.array().items(
     Joi.object().keys({
       link: Joi.string(),

--- a/test-challenges.js
+++ b/test-challenges.js
@@ -10,9 +10,6 @@ import ChallengeTitles from './challengeTitles';
 import addAssertsToTapTest from './addAssertsToTapTest';
 import { validateChallenge } from './schema/challengeSchema';
 
-// modern challengeType
-const modern = 6;
-
 let mongoIds = new MongoIds();
 let challengeTitles = new ChallengeTitles();
 
@@ -27,7 +24,15 @@ function evaluateTest(
   test,
   tapTest
 ) {
+  // code and editor provide access to the original text of the solution, which
+  // is needed since the solution itself is likely to change during
+  // transpilation.
   let code = solution;
+  const editor = {
+    getValue() {
+      return code;
+    }
+  };
 
   /* NOTE: Provide dependencies for React/Redux challenges
                * and configure testing environment
@@ -72,14 +77,15 @@ function evaluateTest(
     head = transform(head, options).code;
     solution = transform(solution, options).code;
     tail = transform(tail, options).code;
-    test = transform(test, options).code;
+    test.testString = transform(test.testString, options).code;
 
     const { JSDOM } = require('jsdom');
     // Mock DOM document for ReactDOM.render method
     const jsdom = new JSDOM(`<!doctype html>
                   <html>
                     <body>
-                      <div id="challenge-node"></div>
+                      <div id="root"/>
+                      <div id="challenge-node"/>
                     </body>
                   </html>
                 `);
@@ -94,9 +100,18 @@ function evaluateTest(
   /* eslint-enable no-unused-vars */
   try {
     (() => {
-      return eval(
+      // As async tests are removed by createTest (since tests are run in series
+      // and waiting the default of 5 seconds between each test could result in
+      // an unreasonably slow test suite) the following differs somewhat from
+      // learn/src/client/frame-runner.js
+      const testOrResult = eval(
         head + '\n' + solution + '\n' + tail + '\n' + test.testString
       );
+      if (typeof testOrResult === 'function') {
+        // The function returned is intended to evaluate the text of the
+        // solution, which code contains.
+        testOrResult(() => code);
+      }
     })();
   } catch (e) {
     console.log(head + '\n' + solution + '\n' + tail + '\n' + test.testString);
@@ -202,7 +217,6 @@ Observable.from(getChallenges())
   .flatMap(challengeSpec => {
     return Observable.from(challengeSpec.challenges);
   })
-  .filter(({ challengeType }) => challengeType !== modern)
   .flatMap(challenge => {
     return createTest(challenge);
   })


### PR DESCRIPTION
ISSUES CLOSED: #305

#### Description
<!-- Describe your changes in detail below this line-->
This includes modern challenges in the test suite.  The test suite in `curriculum` is now closer to the test runner `learn` though it still ignores async tests.




<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)


