### PR TITLE
Fixed typo in basic css lesson

### DIFF
--- a/challenges/01-responsive-web-design/basic-css.json
+++ b/challenges/01-responsive-web-design/basic-css.json
@@ -5597,7 +5597,7 @@
       "description": [
         "When you create a variable, it becomes available for you to use inside the element in which you create it. It also becomes available within any elements nested within it. This effect is known as <dfn>cascading</dfn>.",
         "Because of cascading, CSS variables are often defined in the <dfn>:root</dfn> element.",
-        "You can think of the <code>:root</code> element as a container for your entire HTML document, in the same way that an <code>html</code> element is a container for the <code>body</code> element.",
+        "You can think of the <code>:root</code> element as a container for your entire CSS  document, in the same way that an <code>html</code> element is a container for the <code>body</code> element.",
         "By creating your variables in <code>:root</code>, they will be available throughout the whole web page.",
         "<hr>",
         "Define a variable named <code>--penguin-belly</code> in the <code>:root</code> selector and give it the value of <code>pink</code>. You can then see how the value will cascade down to change the value to pink, anywhere that variable is used."


### PR DESCRIPTION
The lesson states:
"You can think of the :root element as a container for your entire HTML document, in the same way that an html element is a container for the body element."

This should be CSS instead of HTML. It should read:
"You can think of the :root element as a container for your entire CSS document, in the same way that an html element is a container for the body element."

This issue is opened in main repo, I have fixed the typo now.

#### Description
<!-- Describe your changes in detail below this line-->





<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [ ] Your pull request targets the `dev` branch.
- [ ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [ ] All new and existing tests pass the command `npm test`.
- [ ] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [ ] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [ ] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #XXXXX

