### PR TITLE
fix(schema): change schema and unpack script to fix tests in main repo

### DIFF
--- a/getChallenges.js
+++ b/getChallenges.js
@@ -42,7 +42,10 @@ function superblockInfo(filePath) {
   }
 }
 
-module.exports = function getChallenges(challengesDir) {
+// unpackFlag is an argument passed by the unpack script in unpack.js
+// which allows us to conditionall omit translations when running
+// the test suite and prevent schema related errors in the main fCC branch
+module.exports = function getChallenges(challengesDir, unpackFlag) {
   if (!challengesDir) {
     challengesDir = 'challenges';
   }
@@ -63,6 +66,8 @@ module.exports = function getChallenges(challengesDir) {
         'react',
         'reactRedux',
         'redux',
+        'releasedOn',
+        unpackFlag ? undefined : 'translations',
         'type'
       ])
     );

--- a/schema/challengeSchema.js
+++ b/schema/challengeSchema.js
@@ -46,7 +46,6 @@ const schema = Joi.object().keys({
       crossDomain: Joi.bool()
     })
   ),
-  releasedOn: Joi.string().allow(''),
   solutions: Joi.array().items(Joi.string().optional()),
   superBlock: Joi.string(),
   superOrder: Joi.number(),
@@ -67,14 +66,7 @@ const schema = Joi.object().keys({
   ),
   template: Joi.string(),
   time: Joi.string().allow(''),
-  title: Joi.string().required(),
-  translations: Joi.object().pattern(
-    /\w+(-\w+)*/,
-    Joi.object().keys({
-      title: Joi.string(),
-      description: Joi.array().items(Joi.string().allow(''))
-    })
-  )
+  title: Joi.string().required()
 });
 
 exports.validateChallenge = function validateChallenge(challenge) {

--- a/unpack.js
+++ b/unpack.js
@@ -3,13 +3,12 @@ import fs from 'fs-extra';
 import path from 'path';
 import browserify from 'browserify';
 import getChallenges from './getChallenges';
-import {UnpackedChallenge, ChallengeFile} from './unpackedChallenge';
+import { UnpackedChallenge, ChallengeFile } from './unpackedChallenge';
 
 // Unpack all challenges
 // from all seed/challenges/00-foo/bar.json files
 // into seed/unpacked/00-foo/bar/000-id.html files
 //
-// todo: unpack translations too
 // todo: use common/app/routes/Challenges/utils/index.js:15 maps
 // to determine format/style for non-JS tests
 // todo: figure out embedded images etc. served from elsewhere in the project
@@ -19,7 +18,7 @@ let unpackedDir = path.join(__dirname, 'unpacked');
 
 // bundle up the test-running JS
 function createUnpackedBundle() {
-  fs.mkdirp(unpackedDir, (err) => {
+  fs.mkdirp(unpackedDir, err => {
     if (err && err.code !== 'EEXIST') {
       console.log(err);
       throw err;
@@ -28,8 +27,7 @@ function createUnpackedBundle() {
     let unpackedFile = path.join(__dirname, 'unpacked.js');
     let b = browserify(unpackedFile).bundle();
     b.on('error', console.error);
-    let unpackedBundleFile =
-      path.join(unpackedDir, 'unpacked-bundle.js');
+    let unpackedBundleFile = path.join(unpackedDir, 'unpacked-bundle.js');
     const bundleFileStream = fs.createWriteStream(unpackedBundleFile);
     bundleFileStream.on('finish', () => {
       console.log('Wrote bundled JS into ' + unpackedBundleFile);
@@ -50,8 +48,9 @@ async function cleanUnpackedDir(unpackedChallengeBlockDir) {
     filePath = path.join(unpackedChallengeBlockDir, filePath);
     return new Promise(() => fs.unlink(filePath));
   };
-  let promises = fs.readdirSync(unpackedChallengeBlockDir)
-    .filter(filePath => (/\.html$/i).test(filePath))
+  let promises = fs
+    .readdirSync(unpackedChallengeBlockDir)
+    .filter(filePath => /\.html$/i.test(filePath))
     .map(promiseToDelete);
   await Promise.all(promises);
 }
@@ -64,7 +63,7 @@ function unpackChallengeBlock(challengeBlock) {
     challengeBlockPath.name
   );
 
-  fs.mkdirp(unpackedChallengeBlockDir, (err) => {
+  fs.mkdirp(unpackedChallengeBlockDir, err => {
     if (err && err.code !== 'EEXIST') {
       console.log(err);
       throw err;
@@ -83,11 +82,11 @@ function unpackChallengeBlock(challengeBlock) {
     delete challengeBlock.fileName;
     delete challengeBlock.superBlock;
     delete challengeBlock.superOrder;
-    let challengeBlockCopy =
-      new ChallengeFile(
-        unpackedChallengeBlockDir,
-        challengeBlockPath.name,
-        '.json');
+    let challengeBlockCopy = new ChallengeFile(
+      unpackedChallengeBlockDir,
+      challengeBlockPath.name,
+      '.json'
+    );
     challengeBlockCopy.write(JSON.stringify(challengeBlock, null, 2));
 
     // unpack each challenge into an HTML file
@@ -104,7 +103,7 @@ function unpackChallengeBlock(challengeBlock) {
 }
 
 createUnpackedBundle();
-let challenges = getChallenges();
+let challenges = getChallenges(null, true);
 challenges.forEach(challengeBlock => {
   unpackChallengeBlock(challengeBlock);
 });

--- a/unpackedChallenge.js
+++ b/unpackedChallenge.js
@@ -358,14 +358,6 @@ class UnpackedChallenge {
     text.push('</div>');
 
     text.push('');
-    text.push('<h2>Released On</h2>');
-    text.push('<div class="unpacked">');
-    text.push('<!--releasedOn-->');
-    text.push(this.challenge.releasedOn);
-    text.push('<!--end-->');
-    text.push('</div>');
-
-    text.push('');
     text.push('<h2>Files</h2>');
     text.push(`
       <p>Format of file:</p>


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail below this line-->
Added an additional argument to the getChallenges function call in unpack.js to act as a flag for
when the unpack script is running. Then modified the lodash omit array so that translations are
included in the array when the test suite is running, but excluded from the array when the unpack
script is running. Effectively this means that the translations are not included in the challenge
block when going through the test suite, but included in the challenge block for the unpack script.
Finally I removed the unnecessary releasedOn section in unpackedChallenge.js, and removed both
releasedOn and translations from challengeSchema.js.

All of these changes should fix the tests over on the main fCC branch.

<!--
Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

or optionally you can click the checkboxes after you have opened the pull request.
-->
#### Pre-Submission Checklist

- [x] Your pull request targets the `dev` branch.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/challenge-tests`)
- [x] All new and existing tests pass the command `npm test`.
- [x] Use `npm run commit` to generate a conventional commit message.
    Learn more here: <https://conventionalcommits.org/#why-use-conventional-commits>
- [x] The changes were done locally on your machine and NOT GitHub web interface.
    If they were done on the web interface you have ensured that you are creating conventional commit messages.

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Partially addresses #204

